### PR TITLE
(fix/release) bump go-version to 1.17

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
this should fix the release action because it should compile on a more recent go version. 