### PR TITLE
fix(httpx): nil ptr panic when loading proxy

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,6 @@ jobs:
       uses: actions/checkout@v1
 
     - name: build container
-      run: make docker
+      run: docker build --build-arg USER_ID=1337 --build-arg GROUP_ID=1337 -t yelaa .
 
     ## TODO push to docker registry from here, once dockerHub is set up

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine as builder
+FROM golang:1.20-alpine as builder
 
 WORKDIR /root
 RUN apk update --no-cache && \
@@ -14,7 +14,7 @@ COPY . .
 RUN make
 
 
-FROM golang:1.19-alpine
+FROM golang:1.20-alpine
 
 ARG USER_ID
 ARG GROUP_ID

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,8 @@ dynamic: ## Builds a dynamically linked binary (if you really need to use Proxyc
 .PHONY: clean
 clean: ## Cleans up the project
 	rm -f $(TARGET) $(DynYelaa)
+
+.PHONY: tidy
+tidy: ## runs tidy and formatting
+	@go mod tidy
+	@gofmt -s -w .

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ You need to have the chrome binary in your path:
 google-chrome
 ```
 
+Go version: `1.20`
+
 # How to install
 
 Manually :

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/projectdiscovery/dnsx v1.0.3
 	github.com/projectdiscovery/fileutil v0.0.0-20210928100737-cab279c5d4b5
 	github.com/projectdiscovery/folderutil v0.0.0-20211210155654-27636c840d7c
+	github.com/projectdiscovery/goflags v0.0.8-0.20211028121123-edf02bc05b1a
 	github.com/projectdiscovery/gologger v1.1.4
 	github.com/projectdiscovery/httpx v1.1.4
 	github.com/projectdiscovery/nuclei-updatecheck-api v0.0.0-20211006155443-c0a8d610a4df
@@ -129,7 +130,6 @@ require (
 	github.com/projectdiscovery/fdmax v0.0.3 // indirect
 	github.com/projectdiscovery/filekv v0.0.0-20210915124239-3467ef45dd08 // indirect
 	github.com/projectdiscovery/goconfig v0.0.0-20210804090219-f893ccd0c69c // indirect
-	github.com/projectdiscovery/goflags v0.0.8-0.20211028121123-edf02bc05b1a // indirect
 	github.com/projectdiscovery/hmap v0.0.2-0.20210917080408-0fd7bd286bfa // indirect
 	github.com/projectdiscovery/httputil v0.0.0-20210816170244-86fd46bc09f5 // indirect
 	github.com/projectdiscovery/interactsh v0.0.8-0.20220112083504-b0b3b2f359a5 // indirect

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -13,19 +13,19 @@ func GetHome() (home string) {
 	return
 }
 
-func GetHttpTransport() (*http.Transport) {
-    var proxy = os.Getenv("HTTP_PROXY")
-    url, err := url.Parse(proxy)
+func GetHttpTransport() *http.Transport {
+	var proxy = os.Getenv("HTTP_PROXY")
+	url, err := url.Parse(proxy)
 
-    if proxy != "" && err == nil {
-        return &http.Transport{
+	if proxy != "" && err == nil {
+		return &http.Transport{
 			DisableKeepAlives: true,
-            Proxy: http.ProxyURL(url),
-        }
-    }
-    return &http.Transport{}
+			Proxy:             http.ProxyURL(url),
+		}
+	}
+	return &http.Transport{}
 }
 
 func GetUserAgent() string {
-    return "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36"
+	return "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36"
 }

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func loadTargetFile() *FileScanner {
 }
 
 func readFile() {
-    transport := helper.GetHttpTransport()
+	transport := helper.GetHttpTransport()
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
 
 	var toolList []tool.ToolInterface
@@ -73,7 +73,7 @@ func readFile() {
 
 	gb := tool.GoBuster{}
 	cfg := make(map[string]interface{})
-    cfg["proxy"] = proxy
+	cfg["proxy"] = proxy
 	cfg["scanPath"] = scanPath
 	cfg["rateLimiter"] = rateLimit
 	cfg["wordlist"] = wordlist
@@ -151,15 +151,14 @@ func folderNameFactory(names ...string) []folder {
 }
 
 func checkProxy() {
-    os.Setenv("HTTP_PROXY", proxy)
-    os.Setenv("HTTPS_PROXY", proxy)
+	os.Setenv("HTTP_PROXY", proxy)
+	os.Setenv("HTTPS_PROXY", proxy)
 
 	if proxy != "" {
 		color.Cyan("Proxy configuration: %s", proxy)
 	} else {
 		color.Cyan("No proxy has been set")
 	}
-
 
 }
 
@@ -178,7 +177,7 @@ func scanDomain(domain string) {
 	dorks := tool.Dorks{}
 	dorksCfg := make(map[string]interface{})
 
-    dorksCfg["outfile"] = scanPath + "/dorks.txt"
+	dorksCfg["outfile"] = scanPath + "/dorks.txt"
 
 	dorks.Configure(dorksCfg)
 	dorks.Info(domain)
@@ -199,7 +198,7 @@ func scanDomain(domain string) {
 	sf := tool.Subfinder{}
 	configuration := make(map[string]interface{})
 	configuration["filename"] = subdomainsFile.Name()
-    configuration["proxy"] = proxy
+	configuration["proxy"] = proxy
 	sf.Info("")
 	sf.Configure(configuration)
 
@@ -256,11 +255,13 @@ func scanDomain(domain string) {
 	}
 
 	filepath := scanPath + "/osint.domains.txt"
-	httpx := tool.Httpx{}
+	httpx := tool.Httpx{
+		Proxy: proxy,
+	}
 	httpxConfig := make(map[string]interface{})
 	httpxConfig["input"] = scanPath + "/domains.txt"
 	httpxConfig["output"] = filepath
-    httpxConfig["proxy"] = proxy
+
 	httpx.Info("")
 	httpx.Configure(httpxConfig)
 
@@ -272,7 +273,7 @@ func scanDomain(domain string) {
 	gwConfig := make(map[string]interface{})
 	gwConfig["file"] = filepath
 	gwConfig["scanPath"] = scanPath
-    gwConfig["proxy"] = proxy
+	gwConfig["proxy"] = proxy
 
 	gw.Info("")
 	gw.Configure(gwConfig)
@@ -358,7 +359,7 @@ func main() {
 
 			gw := tool.Gowitness{}
 			gwConfig := make(map[string]interface{})
-            gwConfig["proxy"] = proxy
+			gwConfig["proxy"] = proxy
 			gwConfig["scanPath"] = scanPath
 			gwConfig["file"] = filepath
 			gw.Info("")

--- a/main.go
+++ b/main.go
@@ -347,7 +347,9 @@ func main() {
 			}
 
 			filepath := scanPath + "/checkAndScreen.txt"
-			httpx := tool.Httpx{}
+			httpx := tool.Httpx{
+				Proxy: proxy,
+			}
 			httpxConfig := make(map[string]interface{})
 			httpxConfig["input"] = targetPath
 			httpxConfig["output"] = filepath

--- a/tool/dirsearch.go
+++ b/tool/dirsearch.go
@@ -7,17 +7,17 @@ import (
 )
 
 func run(url string) ([]byte, error) {
-    proxy := os.Getenv("HTTP_PROXY")
+	proxy := os.Getenv("HTTP_PROXY")
 
-    if proxy != "" {
-        proxyCmd := fmt.Sprintf("--proxy=%s", proxy)
-        return exec.Command("dirsearch", "-u", url, proxyCmd).Output()
-    }
-    return exec.Command("dirsearch", "-u", url).Output()
+	if proxy != "" {
+		proxyCmd := fmt.Sprintf("--proxy=%s", proxy)
+		return exec.Command("dirsearch", "-u", url, proxyCmd).Output()
+	}
+	return exec.Command("dirsearch", "-u", url).Output()
 }
 
 func Dirsearch(url string) {
-    out, err := run(url)
+	out, err := run(url)
 	if err != nil {
 		fmt.Printf("%s", err)
 	}

--- a/tool/dorks.go
+++ b/tool/dorks.go
@@ -1,14 +1,14 @@
 package tool
 
 import (
+	dorks "github.com/bogdzn/gork/cmd"
 	"github.com/fatih/color"
-    dorks "github.com/bogdzn/gork/cmd"
 )
 
-type Dorks struct{
-    outfile         string
-    userAgent       string
-    extensions      []string
+type Dorks struct {
+	outfile    string
+	userAgent  string
+	extensions []string
 }
 
 func (d *Dorks) Info(url string) {
@@ -17,28 +17,28 @@ func (d *Dorks) Info(url string) {
 
 func (d *Dorks) Configure(c interface{}) {
 
-    /*
-        gork will parse the DOM instead of making an API request, because it's easier for the end user
-        (no API key to worry about etc), so we probably should **not** be changing the page's layout
-        but, it's here in case something breaks
-    */
-    defaultUserAgent := "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36";
-    defaultExtensions := []string{"doc", "docx", "csv", "pdf", "txt", "log", "bak", "json", "xlsx"}
+	/*
+	   gork will parse the DOM instead of making an API request, because it's easier for the end user
+	   (no API key to worry about etc), so we probably should **not** be changing the page's layout
+	   but, it's here in case something breaks
+	*/
+	defaultUserAgent := "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36"
+	defaultExtensions := []string{"doc", "docx", "csv", "pdf", "txt", "log", "bak", "json", "xlsx"}
 
-    d.extensions = defaultExtensions
-    d.userAgent = defaultUserAgent
-    d.outfile = c.(map[string]interface{})["outfile"].(string)
+	d.extensions = defaultExtensions
+	d.userAgent = defaultUserAgent
+	d.outfile = c.(map[string]interface{})["outfile"].(string)
 }
 
 func (d *Dorks) Run(url string) {
-    opts := &dorks.Options{
-        Outfile: d.outfile,
-        AppendResults: true, /* we could be running this in a loop, should not erase former results */
-        Extensions: d.extensions,
-        UserAgent: d.userAgent,
-        Target: url,
-    }
+	opts := &dorks.Options{
+		Outfile:       d.outfile,
+		AppendResults: true, /* we could be running this in a loop, should not erase former results */
+		Extensions:    d.extensions,
+		UserAgent:     d.userAgent,
+		Target:        url,
+	}
 
-    dorks.Run(opts)
-    color.Cyan("Dorks are stored in %s", d.outfile)
+	dorks.Run(opts)
+	color.Cyan("Dorks are stored in %s", d.outfile)
 }

--- a/tool/gobuster.go
+++ b/tool/gobuster.go
@@ -18,7 +18,7 @@ type GoBuster struct {
 	optDir   *gobusterdir.OptionsDir
 	opts     *libgobuster.Options
 	scanPath string
-    proxy    string
+	proxy    string
 }
 
 func (s *GoBuster) Info(website string) {
@@ -42,9 +42,9 @@ func (g *GoBuster) Configure(c interface{}) {
 		}
 	}
 
-    g.proxy = c.(map[string]interface{})["proxy"].(string)
+	g.proxy = c.(map[string]interface{})["proxy"].(string)
 	g.optDir = gobusterdir.NewOptionsDir()
-    g.optDir.UserAgent = helper.GetUserAgent()
+	g.optDir.UserAgent = helper.GetUserAgent()
 	g.optDir.StatusCodesBlacklistParsed.Add(404)
 	g.optDir.NoTLSValidation = true
 	g.optDir.Method = "GET"
@@ -52,9 +52,9 @@ func (g *GoBuster) Configure(c interface{}) {
 	g.optDir.WildcardForced = true
 	g.optDir.StatusCodesBlacklistParsed = blacklist
 	g.opts = &libgobuster.Options{
-        Threads: 10,
-        Wordlist: wordlist,
-    }
+		Threads:  10,
+		Wordlist: wordlist,
+	}
 }
 
 func (g *GoBuster) Run(website string) {

--- a/tool/gowitness.go
+++ b/tool/gowitness.go
@@ -29,7 +29,7 @@ type Gowitness struct {
 	screenshotPath string
 	file           string
 	swg            sizedwaitgroup.SizedWaitGroup
-    proxy          string
+	proxy          string
 }
 
 func (g *Gowitness) Info(_ string) {
@@ -42,8 +42,8 @@ func (g *Gowitness) Configure(config interface{}) {
 	chrm.Delay = 0
 	chrm.FullPage = false
 	chrm.Timeout = 10
-    chrm.Proxy = config.(map[string]interface{})["proxy"].(string)
-    chrm.UserAgent = helper.GetUserAgent()
+	chrm.Proxy = config.(map[string]interface{})["proxy"].(string)
+	chrm.UserAgent = helper.GetUserAgent()
 
 	g.file = config.(map[string]interface{})["file"].(string)
 	g.scanPath = config.(map[string]interface{})["scanPath"].(string)

--- a/tool/httpx.go
+++ b/tool/httpx.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
-	"strings"
 
 	"github.com/fatih/color"
 
@@ -53,14 +52,7 @@ func (h *Httpx) Configure(config interface{}) {
 		Threads:           50,
 		Timeout:           8,
 		RandomAgent:       true,
-	}
-
-	if strings.HasPrefix(h.Proxy, "http") {
-		opts.HTTPProxy = h.Proxy
-	}
-
-	if strings.HasPrefix(h.Proxy, "socks") {
-		opts.SocksProxy = h.Proxy
+		HTTPProxy:         h.Proxy,
 	}
 
 	if httpxconfiguration.Output != "" {

--- a/tool/httpx.go
+++ b/tool/httpx.go
@@ -16,12 +16,13 @@ import (
 type HttpxConfiguration struct {
 	Input  string `json:"input"`
 	Output string `json:"output"`
-    proxy          string
+	proxy  string
 }
 
 type Httpx struct {
 	configuration  HttpxConfiguration
 	runnerInstance *runner.Runner
+	Proxy          string `json:"proxy,omitempty"`
 }
 
 func (h *Httpx) Info(_ string) {
@@ -32,9 +33,8 @@ func (h *Httpx) Configure(config interface{}) {
 	b, _ := json.Marshal(config.(map[string]interface{}))
 	var httpxconfiguration HttpxConfiguration
 	_ = json.Unmarshal(b, &httpxconfiguration)
-    proxy := config.(map[string]interface{})["proxy"].(string)
-
 	h.configuration = httpxconfiguration
+
 	customPorts := customport.CustomPorts{}
 	customPorts.Set("25,80,81,135,389,443,1080,3000,3306,8080,8443,8888,9090,8089")
 
@@ -52,16 +52,16 @@ func (h *Httpx) Configure(config interface{}) {
 		Retries:           2,
 		Threads:           50,
 		Timeout:           8,
-        RandomAgent:       true,
+		RandomAgent:       true,
 	}
 
-    if strings.HasPrefix(proxy, "http") {
-        opts.HTTPProxy = proxy
-    }
+	if strings.HasPrefix(h.Proxy, "http") {
+		opts.HTTPProxy = h.Proxy
+	}
 
-    if strings.HasPrefix(proxy, "socks") {
-        opts.SocksProxy = proxy
-    }
+	if strings.HasPrefix(h.Proxy, "socks") {
+		opts.SocksProxy = h.Proxy
+	}
 
 	if httpxconfiguration.Output != "" {
 		opts.Output = httpxconfiguration.Output

--- a/tool/nuclei.go
+++ b/tool/nuclei.go
@@ -15,7 +15,7 @@ import (
 )
 
 type Nuclei struct {
-    proxy       string
+	proxy       string
 	rateLimiter int32
 }
 
@@ -49,8 +49,8 @@ func (n *Nuclei) Configure(c interface{}) {
 	outputDir := helper.YelaaPath + "/nuclei"
 	n.rateLimiter = c.(map[string]interface{})["rateLimiter"].(int32)
 
-    proxy := c.(map[string]interface{})["proxy"].(string)
-    n.proxy = proxy
+	proxy := c.(map[string]interface{})["proxy"].(string)
+	n.proxy = proxy
 	if _, err := os.Stat(outputDir); os.IsNotExist(err) {
 		if err = os.MkdirAll(outputDir, 0750); err != nil {
 			fmt.Println(err)
@@ -66,17 +66,17 @@ func (n *Nuclei) Run(website string) {
 	outputFile := helper.YelaaPath + "/nuclei/scan_log_nuclei-" + time.Now().Format("2006-01-02_15-04-05") + ".txt"
 	templates_path := filepath.Join(helper.GetHome(), "nuclei-templates/")
 
-    proxy, err := goflags.ToNormalizedStringSlice(n.proxy)
-    if err  != nil {
-        fmt.Println(err)
-    }
+	proxy, err := goflags.ToNormalizedStringSlice(n.proxy)
+	if err != nil {
+		fmt.Println(err)
+	}
 
 	opts := types.Options{
 		TemplatesDirectory: templates_path,
 		Targets:            []string{website},
 		NoInteractsh:       true,
 		Output:             outputFile,
-        Proxy:              proxy,
+		Proxy:              proxy,
 	}
 
 	installTemplatesIfNeeded(templates_path)

--- a/tool/robot.go
+++ b/tool/robot.go
@@ -24,19 +24,19 @@ func (g *Robot) Run(domain string) {
 
 	domain = strings.TrimSuffix(domain, "/")
 
-    transport := helper.GetHttpTransport()
+	transport := helper.GetHttpTransport()
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
-    client := &http.Client{
-        Transport: transport,
-    }
+	client := &http.Client{
+		Transport: transport,
+	}
 
 	for _, u := range getUrls(domain) {
 
-        req, err := http.NewRequest("GET", fmt.Sprint(u, "/robots.txt"), nil)
-        req.Header.Add("User-Agent", helper.GetUserAgent())
+		req, err := http.NewRequest("GET", fmt.Sprint(u, "/robots.txt"), nil)
+		req.Header.Add("User-Agent", helper.GetUserAgent())
 
-        resp, err := client.Do(req)
+		resp, err := client.Do(req)
 
 		if err != nil {
 			fmt.Printf("%v", err)

--- a/tool/sitemap.go
+++ b/tool/sitemap.go
@@ -24,18 +24,18 @@ func (s *Sitemap) Configure(c interface{}) {}
 func (s *Sitemap) Run(domain string) {
 	domain = strings.TrimSuffix(domain, "/")
 
-    transport := helper.GetHttpTransport()
+	transport := helper.GetHttpTransport()
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
-    client := &http.Client{
-        Transport: transport,
-    }
+	client := &http.Client{
+		Transport: transport,
+	}
 
 	for _, u := range getUrls(domain) {
-        req, err := http.NewRequest("GET", fmt.Sprint(u, "/sitemap.xml"), nil)
-        req.Header.Add("User-Agent", helper.GetUserAgent())
+		req, err := http.NewRequest("GET", fmt.Sprint(u, "/sitemap.xml"), nil)
+		req.Header.Add("User-Agent", helper.GetUserAgent())
 
-        resp, err := client.Do(req)
+		resp, err := client.Do(req)
 
 		if err != nil {
 			fmt.Printf("%v", err)

--- a/tool/subfinder.go
+++ b/tool/subfinder.go
@@ -21,7 +21,7 @@ type SubfinderConfiguration struct {
 type Subfinder struct {
 	filename       string
 	runnerInstance *runner.Runner
-    proxy          string
+	proxy          string
 }
 
 func (s *Subfinder) Info(_ string) {
@@ -40,7 +40,7 @@ func (s *Subfinder) Configure(conf interface{}) {
 		Threads:            3,
 		Timeout:            30,
 		MaxEnumerationTime: 10,
-        Proxy:              conf.(map[string]interface{})["proxy"].(string),
+		Proxy:              conf.(map[string]interface{})["proxy"].(string),
 		YAMLConfig: runner.ConfigFile{
 			Resolvers:  resolve.DefaultResolvers,
 			Sources:    passive.DefaultSources,


### PR DESCRIPTION
because config is unmarshalled, it seems that it causes a panic when loading a proxy -- now, it is loaded in Httpx struct directly, so that config can be cleanly un-marshaled

You can test this by doing:
```
echo "jenaye.fr" >> targets.txt

./Yelaa checkAndScreen -p socks5://127.0.0.1:9050 -t targets.txt
```

![image](https://user-images.githubusercontent.com/29751352/230526065-3f884beb-8b4f-4fa6-9b58-00874aae82f3.png)
